### PR TITLE
Updated Dockerfile installation method

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,16 +70,19 @@ RUN apt-get update && apt-get install -y php5-dev php5-cli php-pear php5-mongo c
 #RUN pecl install mongo
 #RUN pecl install mongodb-1.1.9
 
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+RUN curl -sS https://getcomposer.org/installer | php
 
+RUN chmod +x composer.phar
+
+RUN mv composer.phar /usr/local/bin/composer
 
 RUN mkdir -p /session
 
 WORKDIR '/var/www/api'
 
-COPY './www/api/composer.json' '/var/www/api'
+COPY './www/api/composer.json' '/var/www/api/'
 
-RUN cd /var/www/api && composer install
+RUN cd /var/www/api/ && composer install
 
 # Add configuration files
 COPY conf/nginx.conf /etc/nginx/


### PR DESCRIPTION
Changed installation method based on official Composer documentation, in order to avoid error:

"The command '/bin/sh -c cd /var/www/api && composer install' returned a non-zero code: 127"

The installation was being treated in a unified way, I changed it to the cadenced way as well as treated in the documentation.

Also updated added and validated way to run "composer install" in the project folder.

In the tests carried out, it did not run and so the "vendor" folder was not created